### PR TITLE
A few changed to the Mxmlc task

### DIFF
--- a/src/main/groovy/org/gradlefx/tasks/Mxmlc.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/Mxmlc.groovy
@@ -51,7 +51,7 @@ class Mxmlc extends AbstractCompileTask {
 
         //add every source directory
         project.srcDirs.each { sourcePath ->
-            compilerArguments.add("-source-path+=" + project.projectDir.path + sourcePath)
+            compilerArguments.add("-source-path+=" + project.file(sourcePath) )
         }
 
         //add dependencies
@@ -67,7 +67,14 @@ class Mxmlc extends AbstractCompileTask {
         compilerArguments.add("-output=" + project.buildDir.path + '/' + project.output)
 
         //add the target file
-        compilerArguments.add(project.projectDir.path + project.srcDirs.get(0) + '/' + project.mainClass)
+        for (def src : project.srcDirs) {
+            File srcDir = project.file( src )
+            File mcClazz = new File(srcDir, project.mainClass)
+            if (mcClazz.exists()) {
+                compilerArguments.add( mcClazz.absolutePath )
+                break;
+            }
+        }
 
         return compilerArguments
     }


### PR DESCRIPTION
Hi,

I was having problems with Mxmlc as I am trying to compile code where the setting for srcDirs = ['.'], which was inserting the '.' into the path and generating errors.  I decided that since I'd already cloned your repo to see what the code looked like, I'd go ahead and see if I couldn't find a solution.  I believe the use of the project.file() method should solve this problem, and it does seem to work for my use-case, but I have not extensively tested it.

---

Now using project.file() in the Mxmlc task to allow multiple notations for srcDirs, also allow the mainClass MXML file to be in any source directotry (look for it).  Probably could use a few other tweaks too, but this is working for me.
