### PR TITLE
- Fixed bug to ensure that the signed RSLs files will be used within the...

### DIFF
--- a/src/main/groovy/org/gradlefx/conventions/GradleFxConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/GradleFxConvention.groovy
@@ -92,6 +92,9 @@ class GradleFxConvention {
     // player version
     def playerVersion = '10.0'
 
+    // To use debugRLS
+    def useDebugRSLSwfs = true
+
     // HTML wrapper options
     def htmlWrapper
 	

--- a/src/main/groovy/org/gradlefx/tasks/compile/AbstractMxmlc.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/compile/AbstractMxmlc.groovy
@@ -66,7 +66,7 @@ abstract class AbstractMxmlc extends AbstractCompileTask {
 			
 		showAntOutput ant.properties[antOutputProperty]
 	}
-	
+
     def addRsls(List compilerArguments) {
         project.configurations.rsl.files.each { dependency ->
             if (!dependency.exists()) {
@@ -75,4 +75,24 @@ abstract class AbstractMxmlc extends AbstractCompileTask {
 			compilerArguments.add("${CompilerOption.RUNTIME_SHARED_LIBRARY_PATH}+=${dependency.path},${dependency.name[0..-2]}f")
         }
     }
+
+    def addFrameworkRsls(List compilerArguments) {     
+        if (flexConvention.useDebugRSLSwfs == true) {
+            def flexConfig = new XmlSlurper().parse(flexConvention.configPath)
+            flexConfig['runtime-shared-library-path'].each {
+			    String swcName = "${flexConvention.flexHome}/frameworks/" + it['path-element'].text()
+			    String libName =  it['rsl-url'][1].text()[0..-2] + 'f'
+
+	            File dependency = new File(swcName)
+                if (!dependency.exists()) {
+		            throw new ResolveException("Couldn't find the ${dependency.name} file - are you sure the path is correct?")
+		        } else {
+		            compilerArguments.add("${CompilerOption.RUNTIME_SHARED_LIBRARY_PATH}=${dependency.path},${libName}")
+		        }
+            }
+        }
+	}    
+
 }
+    
+

--- a/src/main/groovy/org/gradlefx/util/TemplateUtil.groovy
+++ b/src/main/groovy/org/gradlefx/util/TemplateUtil.groovy
@@ -33,6 +33,7 @@ class TemplateUtil {
     *  <li>${compilerArgs}: additional compiler arguments</li>
     *  <li>${mainSrc}: the main source folder</li>
     *  <li>${playerVersion}: the target Flash player version</li>
+    *  <li>${useDebugRSLSwfs}: to use debug RSL or not</li>
     *  <li>${uuid}: a generated unique identifier</li>
     *  <li>${applicationId}: a generated air/mobile application identifier</li>
     *  <li>${version}: the application's version number</li>
@@ -58,6 +59,7 @@ class TemplateUtil {
                              .replaceAll(/\$\{uuid\}/, flexConvention.uuid)
                              .replaceAll(/\$\{appId\}/, flexConvention.applicationId)
                              .replaceAll(/\$\{version\}/, flexConvention.version)
+                             .replaceAll(/\$\{useDebugRSLSwfs\}/, flexConvention.useDebugRSLSwfs.toString())
            }
        }
    }

--- a/src/main/resources/templates/flashbuilder/air-as.actionScriptProperties
+++ b/src/main/resources/templates/flashbuilder/air-as.actionScriptProperties
@@ -16,7 +16,7 @@
 			strict="true" 
 			targetPlayerVersion="${playerVersion}"
 			useApolloConfig="true" 
-			useDebugRSLSwfs="true" 
+			useDebugRSLSwfs="${useDebugRSLSwfs}" 
 			verifyDigests="true" 
 			warn="true">
 

--- a/src/main/resources/templates/flashbuilder/air-fx.actionScriptProperties
+++ b/src/main/resources/templates/flashbuilder/air-fx.actionScriptProperties
@@ -16,7 +16,7 @@
 			strict="true" 
 			targetPlayerVersion="${playerVersion}" 
 			useApolloConfig="true" 
-			useDebugRSLSwfs="true" 
+			useDebugRSLSwfs="${useDebugRSLSwfs}" 
 			verifyDigests="true" 
 			warn="true">
 

--- a/src/main/resources/templates/flashbuilder/mobile-as.actionScriptProperties
+++ b/src/main/resources/templates/flashbuilder/mobile-as.actionScriptProperties
@@ -16,7 +16,7 @@
 			strict="true" 
 			targetPlayerVersion="${playerVersion}" 
 			useApolloConfig="true" 
-			useDebugRSLSwfs="true" 
+			useDebugRSLSwfs="${useDebugRSLSwfs}" 
 			verifyDigests="true" 
 			warn="true">
 

--- a/src/main/resources/templates/flashbuilder/mobile-fx.actionScriptProperties
+++ b/src/main/resources/templates/flashbuilder/mobile-fx.actionScriptProperties
@@ -16,7 +16,7 @@
 			strict="true" 
 			targetPlayerVersion="${playerVersion}" 
 			useApolloConfig="true" 
-			useDebugRSLSwfs="true" 
+			useDebugRSLSwfs="${useDebugRSLSwfs}" 
 			verifyDigests="true" 
 			warn="true">
 

--- a/src/main/resources/templates/flashbuilder/swf-as.actionScriptProperties
+++ b/src/main/resources/templates/flashbuilder/swf-as.actionScriptProperties
@@ -16,7 +16,7 @@
 			strict="true" 
 			targetPlayerVersion="${playerVersion}" 
 			useApolloConfig="false" 
-			useDebugRSLSwfs="true" 
+			useDebugRSLSwfs="${useDebugRSLSwfs}" 
 			verifyDigests="true"
 			warn="true">
 

--- a/src/main/resources/templates/flashbuilder/swf-fx.actionScriptProperties
+++ b/src/main/resources/templates/flashbuilder/swf-fx.actionScriptProperties
@@ -16,7 +16,7 @@
 			strict="true" 
 			targetPlayerVersion="${playerVersion}" 
 			useApolloConfig="false" 
-			useDebugRSLSwfs="true" 
+			useDebugRSLSwfs="${useDebugRSLSwfs}" 
 			verifyDigests="true" 
 			warn="true">
 


### PR DESCRIPTION
- Fixed bug to ensure that the signed RSLs files will be used within the generate flex project
- Added option useDebugRSLSwfs that can be set to true or false to allow the use for framework unsigned SWF files or using signed SWZ files.
