### PR TITLE
Ability to provide a source for htmlTemplate task

### DIFF
--- a/src/main/groovy/org/gradlefx/conventions/HtmlWrapperConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/HtmlWrapperConvention.groovy
@@ -32,6 +32,7 @@ class HtmlWrapperConvention {
     private Boolean versionDetection = true
     private String output
     private String source
+    private Map tokenReplacements = [:]
     
     public HtmlWrapperConvention(Project project) {
         title       = project.description
@@ -139,5 +140,13 @@ class HtmlWrapperConvention {
     
     void source(File source) {
         this.source = source
+    }
+    
+    Map getTokenReplacements() {
+        return tokenReplacements
+    }
+
+    void tokenReplacements(Map tokenReplacements) {
+        this.tokenReplacements = tokenReplacements
     }
 }

--- a/src/main/groovy/org/gradlefx/tasks/HtmlWrapper.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/HtmlWrapper.groovy
@@ -58,13 +58,15 @@ class HtmlWrapper extends DefaultTask {
     }
     
     private def generateCustomWrapper(File source, HtmlWrapperConvention wrapper) {
-        Map tokens = [
+        def defaultTokens = [
             application:    wrapper.application,
             percentHeight:  "$wrapper.percentHeight%",
             percentWidth:   "$wrapper.percentWidth%",
             swf:            wrapper.swf,
             title:          wrapper.title
         ]
+        
+        def tokens = defaultTokens + wrapper.tokenReplacements
         
         ant.copy(file: source, tofile: "${wrapper.output}/${wrapper.file}") {
             filterchain() {


### PR DESCRIPTION
This is an implementation for #67. 
### Idea

It's the way I used to integrate my own templates when building using ANT. Usually, while developing in Flash Builder I'd end up modifying the template it generates (identical to the one generated by Flex's ANT tasks). Eventually, I'd veer off far from where it started off, but I'd still make use of the automatic token replacement (of type `${..}`) in the template that Flash Builder seamlessly provides. Flex's ANT task does the same token replacement but doesn't allow for the template to be modified.

To achieve the same effect with my own template, I used ANT's copy task in conjunction with token replacement via filterchain. This is essentially what I've added to the htmlWrapper task. It's useful to me, but might not be general enough or well thought through. Feel free to critique.
### Usage

Two new properties are added to the htmlWrapper task, `source` and `tokenReplacements`.

`source` is the path to an existing HTML-file that can be provided as a template instead of generating one using the Flex ANT tasks. If the property isn't provided, the template will be generated like it has before.

`tokenReplacements` is map of replacements for tokens in the provided `source` file. If the template contains the token `${swf}`, it'll be replaced with 'example' if this property contains a `[swf:example]` mapping. If `source` isn't specified, this property will be ignored.

Since the existing properties `title`, `percentHeight`, `percentWidth`, `application` and `swf` are used for token replacement in the ANT generated template, it made sense to make them double as token replacements for the `source` file also.
