### PR TITLE
Look up playerglobal.swc location in flex config xml

### DIFF
--- a/src/main/groovy/org/gradlefx/cli/CommandLineInstruction.groovy
+++ b/src/main/groovy/org/gradlefx/cli/CommandLineInstruction.groovy
@@ -45,7 +45,9 @@ abstract class CommandLineInstruction {
 
     /** Adds the Flash player library to the <code>-external-library-path</code> argument */
     public void addPlayerLibrary() {
-        String libPath = "$flexConvention.flexHome/frameworks/libs/player/{targetPlayerMajorVersion}.{targetPlayerMinorVersion}/playerglobal.swc"
+        def flexConfig = new XmlSlurper().parse(flexConvention.configPath)
+        String libPath = flexConfig['compiler']['external-library-path']['path-element']
+        LOG.info("Adding external library ${libPath}")
         add CompilerOption.EXTERNAL_LIBRARY_PATH, libPath
     }
 


### PR DESCRIPTION
I'm working on a project that uses an older version of the Flex SDK. In this SDK the playerglobal.swc is located in a directory:

```
frameworks/libs/player/{targetPlayerMajorVersion}/playerglobal.swc
```

So the hardcoded path in CommandLineInstruction.groovy gives problems. This change looks up the path in the flex config xml.

I'm not particularly familiar with flex so I'm not sure if this is the right fix. Some way to configure this path would be nice though.
