### PR TITLE
adds an adtAdditionalOptions to the AIRConvention

### DIFF
--- a/src/main/groovy/org/gradlefx/conventions/AIRConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/AIRConvention.groovy
@@ -27,7 +27,8 @@ class AIRConvention {
     private String storepass = null
     private String applicationDescriptor
     private List<ConfigurableFileTree> includeFileTrees = null
-    
+    private List<String> adtAdditionalOptions = new ArrayList<String>();
+	
     public AIRConvention(Project project) {
         keystore = "${project.name}.p12"
         applicationDescriptor = "src/main/actionscript/${project.name}.xml"
@@ -37,6 +38,14 @@ class AIRConvention {
         ConfigureUtil.configure(closure, this)
     }
 
+	List<String> adtAdditionalOptions() {
+		return adtAdditionalOptions;
+	}
+	
+	void adtAdditionalOptions(List<String> adtAdditionalOptions) {
+		this.adtAdditionalOptions = adtAdditionalOptions;
+	}
+	
     String getKeystore() {
         return keystore
     }

--- a/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
@@ -66,7 +66,7 @@ class AirPackage extends DefaultTask {
         List airOptions = [CompilerOption.PACKAGE]
 
         addAirSigningOptions airOptions
-
+		airOptions.addAll(flexConvention.air.adtAdditionalOptions)
         airOptions.addAll([
             project.file(project.buildDir.name + '/' + flexConvention.output).absolutePath,
             project.relativePath(flexConvention.air.applicationDescriptor),


### PR DESCRIPTION
This allows you to pass additional options to ADT

Example of building a captive runtime bundle

air {
adtAdditionalOptions = ['-target', 'bundle']
}
