### PR TITLE
patch for #123 that generates test names as fully qualified class names to avoid ambiguity

### DIFF
--- a/src/main/groovy/org/gradlefx/tasks/Test.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/Test.groovy
@@ -141,10 +141,9 @@ class Test extends DefaultTask {
     }
 
     def Set<String> gatherTestClassNames() {
-        //transform list of fully qualified names to a list of classnames
-        gatherFullyQualifiedTestClassNames().collect {
-            it.tokenize('.')[-1]
-        }
+        //fully qualified test class names are required because test 
+        //classes can have the same name but in different package structures.
+        gatherFullyQualifiedTestClassNames()
     }
 
     private void runTests() {


### PR DESCRIPTION
fixes #123
