### PR TITLE
Update ApplicationCommandLineInstruction.groovy

### DIFF
--- a/src/main/groovy/org/gradlefx/cli/ApplicationCommandLineInstruction.groovy
+++ b/src/main/groovy/org/gradlefx/cli/ApplicationCommandLineInstruction.groovy
@@ -63,7 +63,7 @@ class ApplicationCommandLineInstruction extends CommandLineInstruction {
     }
     
     public void addOutput() {
-        addOutput "${project.buildDir.name}/${flexConvention.output}.swf"
+        addOutput "${project.buildDir.path}/${flexConvention.output}.swf"
     }
     
     public void addMainClass() {


### PR DESCRIPTION
fix for using only last directory name name instead of builddir.path
