### PR TITLE
Adding ignoreFailures property to flexunit

### DIFF
--- a/src/main/groovy/org/gradlefx/conventions/FlexUnitConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/FlexUnitConvention.groovy
@@ -34,7 +34,7 @@ class FlexUnitConvention {
     private Boolean haltOnFailure   = false
     private Boolean verbose         = false
     private Boolean localTrusted    = true
-	private Boolean ignoreFailures  = true
+    private Boolean ignoreFailures  = true
     private int port                = 1024
     private int buffer              = 262144
     private int timeout             = 60000 //60 seconds
@@ -120,13 +120,13 @@ class FlexUnitConvention {
         this.localTrusted = localTrusted
     }
 
-	Boolean getIgnoreFailures() {
-		return ignoreFailures
-	}
+    Boolean getIgnoreFailures() {
+        return ignoreFailures
+    }
 
-	void ignoreFailures(Boolean ignoreFailures) {
-		this.ignoreFailures = ignoreFailures
-	}
+    void ignoreFailures(Boolean ignoreFailures) {
+        this.ignoreFailures = ignoreFailures
+    }
 
     int getPort() {
         return port

--- a/src/main/groovy/org/gradlefx/tasks/Test.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/Test.groovy
@@ -168,8 +168,8 @@ class Test extends DefaultTask {
 
         if (ant.properties[flexUnit.failureProperty] == "true") {
             def msg = 'Tests failed'
-	        if (flexUnit.ignoreFailures) { LOG.warn(msg) }
-	        else { throw new Exception(msg) }
+            if (flexUnit.ignoreFailures) { LOG.warn(msg) }
+            else { throw new Exception(msg) }
         }
     }
 


### PR DESCRIPTION
Sometimes test failures occur (especially with some async tests). Don't want my build to fail on jenkins as a result but rather let the xUnit plugin track failures.
