### PR TITLE
add locale folder as source

### DIFF
--- a/src/main/groovy/org/gradlefx/ide/tasks/IdeaProject.groovy
+++ b/src/main/groovy/org/gradlefx/ide/tasks/IdeaProject.groovy
@@ -259,7 +259,6 @@ class IdeaProject extends AbstractIDEProject {
             def parent = new Node(component, 'content', [url: "file://\$MODULE_DIR\$"])
 
             def addSrcFolder = { folder, isTest ->
-                println "adding source folder: " + folder
                 return new Node(parent, 'sourceFolder', [
                         url: "file://\$MODULE_DIR\$/" + folder,
                         isTestSource: "$isTest"


### PR DESCRIPTION
Mark locale dir as source folder in idea module to fix "Cannot resolve property bundle" error.
