### PR TITLE
Reset configPath when flexHome changes so the value can be rebuilt using the correct path

### DIFF
--- a/src/main/groovy/org/gradlefx/conventions/GradleFxConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/GradleFxConvention.groovy
@@ -43,6 +43,7 @@ class GradleFxConvention {
     public void setFlexHome(String flexHome) {
         //convert relative paths to absolute ones to prevent ANT from freaking out
         this.flexHome = flexHome ? new File(flexHome).absolutePath : null
+        this.configPath = null // Reset configPath when flexHome changes so it can be rebuilt
     }
 
     //The name you want to give to the SDK


### PR DESCRIPTION
When there's no valid flexHome value set during configuration, the configPath will be initialized to "null/frameworks/flex-config.xml" and will stay like this even if the flexHome is changed later, making the build fail.

By resetting the configPath every time we change the flexHome we ensure that the correct config file is used when the Flex SDK is changed during the build bringing more robustness and consistency to the system.
