### PR TITLE
Add support for pure ActionScript test runner

### DIFF
--- a/src/main/groovy/org/gradlefx/tasks/Test.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/Test.groovy
@@ -89,6 +89,7 @@ class Test extends DefaultTask {
 
     private void createFlexUnitRunnerFromTemplate() {
         String templateText = retreiveTemplateText()
+        String templateFileName = getTemplateFileName()
 
         Set<String> fullyQualifiedNames = gatherFullyQualifiedTestClassNames()
         Set<String> classNames = gatherTestClassNames()
@@ -103,7 +104,7 @@ class Test extends DefaultTask {
         def outputDir = project.file(flexConvention.flexUnit.toDir)
         if (!outputDir.exists()) outputDir.mkdirs()
 
-        File destinationFile = project.file("${flexConvention.flexUnit.toDir}/FlexUnitRunner.mxml")
+        File destinationFile = project.file("${flexConvention.flexUnit.toDir}/${templateFileName}")
         destinationFile.createNewFile()
         destinationFile.write(template.toString())
     }
@@ -119,6 +120,17 @@ class Test extends DefaultTask {
         }
 
         templateText
+    }
+
+    private String getTemplateFileName() {
+        def name
+        if(flexConvention.flexUnit.template != null && flexConvention.flexUnit.template.endsWith(".as")) {
+            name = "FlexUnitRunner.as"
+        } else {
+            name = "FlexUnitRunner.mxml"
+        }
+
+        name
     }
 
     def Set<String> gatherFullyQualifiedTestClassNames() {


### PR DESCRIPTION
Hi,
I'm using the default flex unit runner generated by FlashBuilder. It's called FlexUnitApplication.as and how you can see, it's written in pure ActionScript, no Flex. 

If I try:

```
flexUnit {
    template = 'src/FlexUnitApplication.as'
}
```

build fails with following error:

```
build/gradle/build/reports/FlexUnitRunner.mxml(1): col: 1 Error: Content is not allowed in prolog.

  package
  ^
```

The problem is that gradlefx copies the content of the .as file into the .mxml file.
