### PR TITLE
-sampler option is added to air mobile convention

### DIFF
--- a/src/main/groovy/org/gradlefx/cli/CompilerOption.groovy
+++ b/src/main/groovy/org/gradlefx/cli/CompilerOption.groovy
@@ -1345,7 +1345,14 @@ public enum CompilerOption {
      * type: string
      * default: API documentation
      */
-    WINDOW_TITLE("-window-title")
+    WINDOW_TITLE("-window-title"),
+
+    /**
+     * (iOS only, AIR 3.4 and higher) Enables the telemetry-based ActionScript sampler in iOS applications.
+     * Using this flag lets you profile the application with Adobe Scout.
+     * Note that using this flag will have a slight performance impact, so do not use it for production applications.
+     */
+    IOS_SAMPLER("-sampler")
     
 
     private String optionName;

--- a/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
@@ -102,12 +102,17 @@ class AIRMobileConvention  {
      */
     private String simulatorTargetDevice
 
+    /**
+     * Specifies whether -sampler option is used at the packaging phase
+     */
+    private Boolean sampler
 
     public AIRMobileConvention(Project project) {
         target = 'apk'
         simulatorTarget = 'apk'
         outputExtension = 'apk'
         platform = 'android'
+        sampler = false
     }
 
     void configure(Closure closure) {
@@ -198,5 +203,11 @@ class AIRMobileConvention  {
         this.simulatorPlatformSdk = platformSdk
     }
 
+    Boolean getSampler() {
+        return sampler
+    }
 
+    void sampler(Boolean sampler) {
+        this.sampler = sampler
+    }
 }

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -42,6 +42,10 @@ class BaseAirMobilePackage extends AdtTask {
         addArg CompilerOption.TARGET.optionName
         addArg target
 
+        if(flexConvention.airMobile.sampler) {
+            addArg CompilerOption.IOS_SAMPLER.optionName
+        }
+
         if (StringUtils.isNotEmpty(flexConvention.airMobile.provisioningProfile)) {
             addArgs CompilerOption.PROVISIONING_PROFILE.optionName, flexConvention.airMobile.provisioningProfile
         }


### PR DESCRIPTION
iOS only, AIR 3.4 and higher) Enables the telemetry-based ActionScript sampler in iOS applications.
