### PR TITLE
add possibility to use new adobe air fast compiler for IOS packaging sin...

### DIFF
--- a/src/main/groovy/org/gradlefx/cli/CompilerOption.groovy
+++ b/src/main/groovy/org/gradlefx/cli/CompilerOption.groovy
@@ -1352,8 +1352,17 @@ public enum CompilerOption {
      * Using this flag lets you profile the application with Adobe Scout.
      * Note that using this flag will have a slight performance impact, so do not use it for production applications.
      */
-    IOS_SAMPLER("-sampler")
-    
+    IOS_SAMPLER("-sampler"),
+
+    /**
+     * Enables to using the new non legacy compiler for packaging IPA
+     *
+     * target platform: IOS
+     * version: AIR 14 and higher
+     *
+     */
+    USE_LEGACY_COMPILER("-useLegacyAOT")
+
 
     private String optionName;
 

--- a/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
@@ -107,6 +107,11 @@ class AIRMobileConvention  {
      */
     private Boolean sampler
 
+    /**
+     * Specifies whether -useLegacyAOT with flag 'no' option is used at the packaging phase
+     */
+    private Boolean nonLegacyCompiler
+
     public AIRMobileConvention(Project project) {
         target = 'apk'
         simulatorTarget = 'apk'
@@ -209,5 +214,13 @@ class AIRMobileConvention  {
 
     void sampler(Boolean sampler) {
         this.sampler = sampler
+    }
+
+    Boolean getNonLegacyCompiler() {
+        return nonLegacyCompiler
+    }
+
+    void setNonLegacyCompiler(Boolean nonLegacyCompiler) {
+        this.nonLegacyCompiler = nonLegacyCompiler
     }
 }

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -46,6 +46,10 @@ class BaseAirMobilePackage extends AdtTask {
             addArg CompilerOption.IOS_SAMPLER.optionName
         }
 
+        if(flexConvention.airMobile.nonLegacyCompiler) {
+            addArgs CompilerOption.USE_LEGACY_COMPILER.optionName, "no"
+        }
+
         if (StringUtils.isNotEmpty(flexConvention.airMobile.provisioningProfile)) {
             addArgs CompilerOption.PROVISIONING_PROFILE.optionName, flexConvention.airMobile.provisioningProfile
         }


### PR DESCRIPTION
Enables to using the new non legacy compiler for packaging IPA since Adobe Air 14
