### PR TITLE
IDEA project generation: Only set air iOS SDK if it has a value

### DIFF
--- a/src/main/groovy/org/gradlefx/ide/tasks/idea/IdeaProject.groovy
+++ b/src/main/groovy/org/gradlefx/ide/tasks/idea/IdeaProject.groovy
@@ -244,9 +244,13 @@ class IdeaProject extends AbstractIDEProject {
                         configuration.'packaging-ios'.@'enabled' = true
 
                         def attrs = ['keystore-path':"\$MODULE_DIR\$/${FilenameUtils.separatorsToUnix(project.relativePath(flexConvention.air.keystore))}",
-                                     'use-temp-certificate':false,
-                                     sdk:flexConvention.airMobile.platformSdk
+                                     'use-temp-certificate':false
                                     ];
+                        if (flexConvention.airMobile.platformSdk != null)
+                        {
+                            attrs['sdk'] = flexConvention.airMobile.platformSdk
+                        }
+
                         if (flexConvention.airMobile.provisioningProfile != null) {
                             attrs['provisioning-profile-path']  = "\$MODULE_DIR\$/${FilenameUtils.separatorsToUnix(project.relativePath(flexConvention.airMobile.provisioningProfile))}"
                         }


### PR DESCRIPTION
This prevents the sdk having "null" value if its not set
