### PR TITLE
Support adding files to an IDEA project from flexConvention.air.fileOptions

### DIFF
--- a/src/main/groovy/org/gradlefx/ide/tasks/idea/IdeaProject.groovy
+++ b/src/main/groovy/org/gradlefx/ide/tasks/idea/IdeaProject.groovy
@@ -290,15 +290,12 @@ class IdeaProject extends AbstractIDEProject {
 
         List<String> opts = flexConvention.air.fileOptions
         if (opts) {
-            File currentDir = project.rootDir
             String currDir = ''
             for (int i; i<opts.size(); i++) {
                 if (opts[i] == CompilerOption.CHANGE_DIRECTORY.optionName) {
                     i++
-                    currentDir = new File(project.rootDir, opts[i])
                     currDir = opts[i]
                 } else {
-                    File toAdd = new File(currentDir, opts[i])
                     new Node(filesParent, 'FilePathAndPathInPackage', ['file-path':'$MODULE_DIR$/'+currDir+'/'+opts[i], 'path-in-package':opts[i]])
                 }
             }


### PR DESCRIPTION
With this commit included files in AIR builds that were added via fileOptions are parsed into IDEA.

For example:

```
air {
    fileOptions = [
        CompilerOption.CHANGE_DIRECTORY.optionName,'media',
        'Default@2x.png',
        'Default-568h@2x.png',
        ....
    ]
}
```

is parsed into IDEA's `Files and folders to package` list in the Android & iOS tabs in the build configuration.
