### PR TITLE
IDEA project generation: Set output directory to the project's build directory

### DIFF
--- a/src/main/groovy/org/gradlefx/util/TemplateUtil.groovy
+++ b/src/main/groovy/org/gradlefx/util/TemplateUtil.groovy
@@ -59,6 +59,7 @@ class TemplateUtil {
                              .replaceAll(/\$\{artifact\}/, artifact())
                              .replaceAll(/\$\{useDebugRSLSwfs\}/, {flexConvention.useDebugRSLSwfs.toString()})
                              .replaceAll(/\$\{useApolloConfig\}/, {useApolloConfig})
+                             .replaceAll(/\$\{buildDir\}/, {project.buildDir.name})
            }
        }
    }

--- a/src/main/resources/templates/idea/template-iml.xml
+++ b/src/main/resources/templates/idea/template-iml.xml
@@ -6,7 +6,7 @@
   </component>
   <component name="FlexBuildConfigurationManager" active="${project}">
     <configurations>
-      <configuration name="${project}" pure-as="false" output-type="Library" output-file="${artifact}" output-folder="$MODULE_DIR$/bin-debug">
+      <configuration name="${project}" pure-as="false" output-type="Library" output-file="${artifact}" output-folder="$MODULE_DIR$/${buildDir}">
         <!-- TODO target.player dependency ? -->
         <dependencies target-player="${playerVersion}" framework-linkage="Merged">
             <entries>
@@ -36,8 +36,8 @@
     <compiler-options />
   </component>
   <component name="NewModuleRootManager" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/bin-debug" />
-    <output-test url="file://$MODULE_DIR$/bin-debug" />
+    <output url="file://$MODULE_DIR$/${buildDir}" />
+    <output-test url="file://$MODULE_DIR$/${buildDir}" />
     <exclude-output />
       <!--<content url="file://$MODULE_DIR$"> -->
           <!-- TODO sources -->

--- a/src/test/groovy/org/gradlefx/ide/tasks/IdeaProjectTest.groovy
+++ b/src/test/groovy/org/gradlefx/ide/tasks/IdeaProjectTest.groovy
@@ -60,7 +60,7 @@ class IdeaProjectTest {
         given_project_type_is("swc")
         given_project_outputname_is("OliverClothesoff")
         when_I_create_project_config()
-        then_the_iml_file_should_have_tag('<configuration name="AmandaHuggenkiss" pure-as="false" output-type="Library" output-file="OliverClothesoff.swc" output-folder="$MODULE_DIR$/bin-debug">')
+        then_the_iml_file_should_have_tag('<configuration name="AmandaHuggenkiss" pure-as="false" output-type="Library" output-file="OliverClothesoff.swc" output-folder="$MODULE_DIR$/build">')
     }
 
     @Test


### PR DESCRIPTION
This is useful because AIR projects can have assets that are used by the binary in the build folder. If a console build puts the binary into a different location than IDEA, then one will break. For example one of our mobile builds has a "prepare assets" phase that copies images and XML files into the build directory. Then the app loads these at runtime (specified as a relative path).
