### PR TITLE
Add support for absolute path buildDir (use .path instead of .name)

### DIFF
--- a/src/main/groovy/org/gradlefx/cli/instructions/airsdk/standalone/actionscriptonly/LibraryInstructions.groovy
+++ b/src/main/groovy/org/gradlefx/cli/instructions/airsdk/standalone/actionscriptonly/LibraryInstructions.groovy
@@ -54,7 +54,7 @@ class LibraryInstructions extends CompilerInstructionsBuilder implements SimpleC
     }
 
     public void addOutput() {
-        addOutput "${project.buildDir.name}/${flexConvention.output}.swc"
+        addOutput "${project.buildDir.path}/${flexConvention.output}.swc"
     }
     
 }

--- a/src/main/groovy/org/gradlefx/cli/instructions/flexsdk/LibraryInstructions.groovy
+++ b/src/main/groovy/org/gradlefx/cli/instructions/flexsdk/LibraryInstructions.groovy
@@ -56,7 +56,7 @@ class LibraryInstructions extends CompilerInstructionsBuilder implements Library
     }
     
     public void addOutput() {
-        addOutput "${project.buildDir.name}/${flexConvention.output}.swc"
+        addOutput "${project.buildDir.path}/${flexConvention.output}.swc"
     }
     
 }

--- a/src/main/groovy/org/gradlefx/plugins/GradleFxPlugin.groovy
+++ b/src/main/groovy/org/gradlefx/plugins/GradleFxPlugin.groovy
@@ -94,7 +94,7 @@ class GradleFxPlugin extends AbstractGradleFxPlugin {
      */
     private void addArtifactsToDefaultConfiguration(Project project) {
         String type = flexConvention.type.toString()
-        File artifactFile = project.file project.buildDir.name + "/" + flexConvention.output + "." + type
+        File artifactFile = project.file project.buildDir.path + "/" + flexConvention.output + "." + type
         PublishArtifact artifact = new DefaultPublishArtifact(project.name, type, type, null, new Date(), artifactFile)
 
         project.artifacts { ArtifactHandler artifactHandler ->


### PR DESCRIPTION
Small change that appears to fix the bug I reported in #164.