### PR TITLE
Resolve #166: add 'swcAir' artifacts with '.swc' file extension

### DIFF
--- a/src/main/groovy/org/gradlefx/plugins/GradleFxPlugin.groovy
+++ b/src/main/groovy/org/gradlefx/plugins/GradleFxPlugin.groovy
@@ -94,7 +94,8 @@ class GradleFxPlugin extends AbstractGradleFxPlugin {
      */
     private void addArtifactsToDefaultConfiguration(Project project) {
         String type = flexConvention.type.toString()
-        File artifactFile = project.file project.buildDir.path + "/" + flexConvention.output + "." + type
+        String fileExt = (flexConvention.type.isLib() ? 'swc' : type)
+        File artifactFile = project.file project.buildDir.path + "/" + flexConvention.output + "." + fileExt
         PublishArtifact artifact = new DefaultPublishArtifact(project.name, type, type, null, new Date(), artifactFile)
 
         project.artifacts { ArtifactHandler artifactHandler ->


### PR DESCRIPTION
Per issue #166, correct the scenario where a swcAir dependent library is not added as a `-library-path` entry to the compiler arguments.

There might be other cases where we need to convert a particular flexType to use a different file extension than the name of the type, but I haven't explored that possibility (yet).