### PR TITLE
Add the -arch package option for AIR Android.

### DIFF
--- a/src/main/groovy/org/gradlefx/cli/compiler/CompilerOption.groovy
+++ b/src/main/groovy/org/gradlefx/cli/compiler/CompilerOption.groovy
@@ -1363,8 +1363,15 @@ public enum CompilerOption {
      * version: AIR 14 and higher
      *
      */
-    USE_LEGACY_COMPILER("-useLegacyAOT")
+    USE_LEGACY_COMPILER("-useLegacyAOT"),
 
+    /**
+     * (Android only, AIR 14 and higher) Application developers can use this argument to create APK for x86 platforms,
+     * it takes following values:
+     * armv7 - ADT packages APK for the Android armv7 platform. This is the default value when no value is specified.
+     * x86 - ADT packages APK for the Android x86 platform.
+     */
+    ARCH("-arch")
 
     private String optionName;
 

--- a/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
@@ -112,6 +112,14 @@ class AIRMobileConvention  {
      */
     private Boolean nonLegacyCompiler
 
+    /**
+     * (Android only, AIR 14 and higher) Application developers can use this argument to create APK for x86 platforms,
+     * it takes following values:
+     * armv7 - ADT packages APK for the Android armv7 platform. This is the default value when no value is specified.
+     * x86 - ADT packages APK for the Android x86 platform.
+     */
+    private String arch
+
     public AIRMobileConvention(Project project) {
         target = 'apk'
         simulatorTarget = 'apk'
@@ -222,5 +230,13 @@ class AIRMobileConvention  {
 
     void setNonLegacyCompiler(Boolean nonLegacyCompiler) {
         this.nonLegacyCompiler = nonLegacyCompiler
+    }
+
+    String getArch() {
+        return arch
+    }
+
+    void setArch(String arch) {
+        this.arch = arch
     }
 }

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -43,6 +43,11 @@ class BaseAirMobilePackage extends AdtTask {
         addArg CompilerOption.TARGET.optionName
         addArg target
 
+        if(flexConvention.airMobile.arch) {
+            addArg CompilerOption.ARCH.optionName
+            addArg flexConvention.airMobile.arch
+        }
+
         if(flexConvention.airMobile.sampler) {
             addArg CompilerOption.IOS_SAMPLER.optionName
         }


### PR DESCRIPTION
This adds the -arch option for ADT. Using -arch x86 is the only way to run AIR on certain devices, and on other x86 devices it makes the application much faster (my test app runs ~3x faster with this option on an Android tablet with an Intel CPU)

For more info see http://blogs.adobe.com/flashplayer/2014/04/adobe-air-now-supports-x86-android.html