### PR TITLE
Display adt args to info, like AdtTask.groovy does.

### DIFF
--- a/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
@@ -55,6 +55,7 @@ class AirPackage extends DefaultTask {
                 outputproperty: ANT_OUTPUT_PROPERTY) {
 
             compilerArguments.each { compilerArgument ->
+                logger.info("adt args: {}", compilerArgument)
                 arg(value: compilerArgument)
             }
         }


### PR DESCRIPTION
Displaying the arguments to the adt.jar call is very helpful in seeing/confirming what's being passed.
Since the compiler and the packageMobile tasks already did, seemed like a no-brainer to add it here.