### PR TITLE
Declare inputs and outputs for package and packageMobile tasks.

### DIFF
--- a/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
@@ -70,15 +70,28 @@ class AirPackage extends DefaultTask {
     }
 
     def initInputOutputFiles() {
-        def swfFileName
-        if (flexConvention.air.mainSwfDir) {
-            swfFileName = new File(project.buildDir.path, "${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").toString()
-        } else {
-            swfFileName = "${project.buildDir.path}/${flexConvention.output}.${FlexType.swf}"
-        }
+        if (project.type == FlexType.air) {
+            if (flexConvention.air.keystore) {
+                def keystore = project.file(flexConvention.air.keystore)
+                if (keystore.exists()) {
+                    inputs.files keystore.absolutePath
+                }
+            }
 
-        inputs.files swfFileName
-        outputs.files project.file(project.buildDir.name + '/' + flexConvention.output).absolutePath
+            if (flexConvention.air.applicationDescriptor) {
+                def appDescriptor = project.file(flexConvention.air.applicationDescriptor)
+                if (appDescriptor.exists()) {
+                    inputs.files appDescriptor.absolutePath
+                }
+            }
+
+            if (flexConvention.air.mainSwfDir) {
+                inputs.files project.file("${project.buildDir}/${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
+            }
+
+            inputs.files  project.file("${project.buildDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
+            outputs.files project.file("${project.buildDir}/${flexConvention.output}.${FlexType.air}").absolutePath
+        }
     }
 
     private List createCompilerArguments() {

--- a/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
@@ -40,6 +40,10 @@ class AirPackage extends DefaultTask {
         flexConvention = (GradleFxConvention) project.convention.plugins.flex
 
         dependsOn Tasks.COMPILE_TASK_NAME
+
+        project.afterEvaluate {
+            initInputOutputFiles()
+        }
     }
 
     @TaskAction
@@ -63,6 +67,18 @@ class AirPackage extends DefaultTask {
         handlePackageIfFailed ANT_RESULT_PROPERTY, ANT_OUTPUT_PROPERTY
 
         showAntOutput ant.properties[ANT_OUTPUT_PROPERTY]
+    }
+
+    def initInputOutputFiles() {
+        def swfFileName
+        if (flexConvention.air.mainSwfDir) {
+            swfFileName = new File(project.buildDir.path, "${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").toString()
+        } else {
+            swfFileName = "${project.buildDir.path}/${flexConvention.output}.${FlexType.swf}"
+        }
+
+        inputs.files swfFileName
+        outputs.files project.file(project.buildDir.name + '/' + flexConvention.output).absolutePath
     }
 
     private List createCompilerArguments() {

--- a/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
@@ -85,11 +85,12 @@ class AirPackage extends DefaultTask {
                 }
             }
 
+            inputs.files  project.file("${project.buildDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
+
             if (flexConvention.air.mainSwfDir) {
-                inputs.files project.file("${project.buildDir}/${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
+                outputs.files project.file("${project.buildDir}/${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
             }
 
-            inputs.files  project.file("${project.buildDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
             outputs.files project.file("${project.buildDir}/${flexConvention.output}.${FlexType.air}").absolutePath
         }
     }

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -148,11 +148,12 @@ class BaseAirMobilePackage extends AdtTask {
                 }
             }
 
+            inputs.files  project.file("${project.buildDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
+
             if (flexConvention.air.mainSwfDir) {
-                inputs.files project.file("${project.buildDir}/${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
+                output.files project.file("${project.buildDir}/${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
             }
 
-            inputs.files  project.file("${project.buildDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
             outputs.files project.file("${project.buildDir}/${flexConvention.output}.${flexConvention.airMobile.outputExtension}").absolutePath
         }
     }

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -126,15 +126,35 @@ class BaseAirMobilePackage extends AdtTask {
     }
 
     def initInputOutputFiles() {
-        def swfFileName
-        if (flexConvention.air.mainSwfDir) {
-            swfFileName = new File(project.buildDir.path, "${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").toString()
-        } else {
-            swfFileName = "${project.buildDir.path}/${flexConvention.output}.${FlexType.swf}"
-        }
+        if (project.type == FlexType.mobile) {
+            if (flexConvention.air.keystore) {
+                def keystore = project.file(flexConvention.air.keystore)
+                if (keystore.exists()) {
+                    inputs.files keystore.absolutePath
+                }
+            }
 
-        inputs.files swfFileName
-        outputs.files project.file(project.buildDir.name + '/' + flexConvention.output).absolutePath
+            if (flexConvention.air.applicationDescriptor) {
+                def appDescriptor = project.file(flexConvention.air.applicationDescriptor)
+                if (appDescriptor.exists()) {
+                    inputs.files appDescriptor.absolutePath
+                }
+            }
+
+            if (flexConvention.airMobile.provisioningProfile) {
+                def provisioningProfile = project.file(flexConvention.airMobile.provisioningProfile)
+                if (provisioningProfile.exists()) {
+                    inputs.files provisioningProfile.absolutePath
+                }
+            }
+
+            if (flexConvention.air.mainSwfDir) {
+                inputs.files project.file("${project.buildDir}/${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
+            }
+
+            inputs.files  project.file("${project.buildDir}/${flexConvention.output}.${FlexType.swf}").absolutePath
+            outputs.files project.file("${project.buildDir}/${flexConvention.output}.${flexConvention.airMobile.outputExtension}").absolutePath
+        }
     }
 
     AIRMobileConvention getAirMobile() {

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -35,6 +35,10 @@ class BaseAirMobilePackage extends AdtTask {
         description = "Packages the generated swf file into an mobile package";
         adtWorkDir = flexConvention.air.packageWorkDir
         dependsOn Tasks.COMPILE_TASK_NAME
+
+        project.afterEvaluate {
+            initInputOutputFiles()
+        }
     }
 
     @TaskAction
@@ -119,6 +123,18 @@ class BaseAirMobilePackage extends AdtTask {
         addPlatformSdkParams()
 
         super.launch()
+    }
+
+    def initInputOutputFiles() {
+        def swfFileName
+        if (flexConvention.air.mainSwfDir) {
+            swfFileName = new File(project.buildDir.path, "${flexConvention.air.mainSwfDir}/${flexConvention.output}.${FlexType.swf}").toString()
+        } else {
+            swfFileName = "${project.buildDir.path}/${flexConvention.output}.${FlexType.swf}"
+        }
+
+        inputs.files swfFileName
+        outputs.files project.file(project.buildDir.name + '/' + flexConvention.output).absolutePath
     }
 
     AIRMobileConvention getAirMobile() {


### PR DESCRIPTION
This is a simple approach to declaring inputs and outputs for the packaging tasks (to address #173). This is intended to start a conversation (@SlevinBE?), as it could likely stand some improvement. Currently, I think it may suffer from:
* It only declares the .swf file as an input -- a good start, but it could also pull in any additional file that goes into the package?
* It feels like there's some code duplication with addMainSwf(), but that function is run during execution, so further refactoring would be needed to use the same bit of code.
* I tried declaring initInputOutputFiles() as a private void method, but Gradle did not like that, so a def it is.
* This approach, if reasonable, could also be applied to the publish task.

Thanks for any feedback.