### PR TITLE
Publish task: Exclude 'tmp' dir when copying.

### DIFF
--- a/src/main/groovy/org/gradlefx/tasks/Publish.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/Publish.groovy
@@ -38,6 +38,7 @@ class Publish extends DefaultTask {
             from project.buildDir
             into flexConvention.publishDir
             include '**/*'
+            exclude 'tmp'
         }
         // copy non-project RSL dependencies to the publish directory
         project.files(project.configurations.rsl) { libraries ->


### PR DESCRIPTION
Because the default location of a task's 'temporaryDir' ("tmp") lies
under a project's buildDir, the publish task can unintentionally copy
this tmp dir when invoked. To ensure this does not happen, the 'tmp'
directory is explicitly excluded from the copy.

Fixes issue #180.