### PR TITLE
Pass flexunit.port to the FlexUnitRunner template

### DIFF
--- a/src/main/groovy/org/gradlefx/tasks/Test.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/Test.groovy
@@ -115,12 +115,14 @@ class Test extends DefaultTask {
     private void createFlexUnitRunnerFromTemplate() {
         String templateText = retreiveTemplateText()
         String templateFileName = getTemplateFileName()
+        FlexUnitConvention flexUnit = flexConvention.flexUnit
 
         Set<String> fullyQualifiedNames = gatherFullyQualifiedTestClassNames()
         Set<String> classNames = gatherTestClassNames()
         def binding = [
             "fullyQualifiedNames": fullyQualifiedNames,
-            "testClasses": classNames
+            "testClasses": classNames,
+            "flexUnitPort": flexUnit.port
         ]
         def engine = new SimpleTemplateEngine()
         def template = engine.createTemplate(templateText).make(binding)

--- a/src/main/resources/templates/flexunit/FlexUnitRunner.mxml
+++ b/src/main/resources/templates/flexunit/FlexUnitRunner.mxml
@@ -29,7 +29,7 @@
         private function onCreationComplete():void {
             var core:FlexUnitCore = new FlexUnitCore();
             core.addListener(new UIListener(uiListener));
-            core.addListener(new CIListener());
+            core.addListener(new CIListener(<%= flexUnitPort %>));
             core.run(currentRunTestSuite());
         }
 


### PR DESCRIPTION
Allows you to do change that the tests use, for example builds in a ci server
can do the following:
```
def random = new Random()
flexUnit {
  port = 49152 + random.nextInt(10000)
  ...
}
```