### PR TITLE
Fix Flex install script for Flex 4.14+ and Feathers SDK

### DIFF
--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/AbstractCreateSdkInstallLocationState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/AbstractCreateSdkInstallLocationState.groovy
@@ -32,14 +32,14 @@ abstract class AbstractCreateSdkInstallLocationState implements SdkInitState {
     SdkInstallLocation installLocation
     String sdkFile
     protected String configName
-    Boolean isInstallationRequired
+    Boolean hasSDKDeclaredAsDependency
     Boolean isInstalled
 
-    AbstractCreateSdkInstallLocationState(SdkType sdkType, String sdkFile, String configName, Boolean isInstallationRequired) {
+    AbstractCreateSdkInstallLocationState(SdkType sdkType, String sdkFile, String configName, Boolean hasSDKDeclaredAsDependency) {
         this.sdkType = sdkType
         this.sdkFile = sdkFile
         this.configName = configName
-        this.isInstallationRequired = isInstallationRequired
+        this.hasSDKDeclaredAsDependency = hasSDKDeclaredAsDependency
         this.isInstalled = false
     }
 

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/air/CreateAirSdkInstallLocationState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/air/CreateAirSdkInstallLocationState.groovy
@@ -30,11 +30,11 @@ class CreateAirSdkInstallLocationState extends AbstractCreateSdkInstallLocationS
     @Override
     SdkInitState nextState() {
         //if lib/adt.jar is found in the SDK installation, it will mark this project as AIR-enabled.
-        if (isInstalled || isInstallationRequired) {
+        if (isInstalled || hasSDKDeclaredAsDependency) {
             flexConvention.sdkTypes.add(SdkType.AIR);
         }
 
-        if (!isInstalled && isInstallationRequired) {
+        if (!isInstalled && hasSDKDeclaredAsDependency) {
             Configuration flexSdkConfiguration = project.configurations.getByName(configName)
             return new InstallAirSdkState(installLocation, flexSdkConfiguration.singleFile)
         } else {

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/CreateFlexSdkInstallLocationState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/CreateFlexSdkInstallLocationState.groovy
@@ -30,11 +30,11 @@ class CreateFlexSdkInstallLocationState extends AbstractCreateSdkInstallLocation
     @Override
     SdkInitState nextState() {
         //if lib/mxmlc.jar is found in the SDK installation, it will mark this project as Flex-enabled.
-        if (isInstalled || isInstallationRequired) {
+        if (isInstalled || hasSDKDeclaredAsDependency) {
             flexConvention.sdkTypes.add(SdkType.Flex);
         }
 
-        if (!isInstalled && isInstallationRequired) {
+        if (!isInstalled && hasSDKDeclaredAsDependency) {
             Configuration flexSdkConfiguration = project.configurations.getByName(configName)
             return new InstallFlexSdkState(installLocation, flexSdkConfiguration.singleFile)
         } else {

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/InstallFlexSdkState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/InstallFlexSdkState.groovy
@@ -102,6 +102,7 @@ class InstallFlexSdkState extends AbstractInstallSdkState {
                 property(name: 'installer', value: true)
             }
             property(name: 'do.air.install', value: true)
+            property(name: 'do.flash.install', value: true)
             property(name: 'do.swfobject.install', value: true)
             property(name: 'do.fontswf.install', value: true)
         }

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/InstallFlexSdkState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/InstallFlexSdkState.groovy
@@ -47,6 +47,10 @@ class InstallFlexSdkState extends AbstractInstallSdkState {
             downloadPlayerGlobalSwc()
             updateFrameworkConfigFiles()
         }
+        else {
+            throw new RuntimeException("Unable to install Flex SDK. No install script found. The script needs either" +
+                    "${getInstallerScriptFile().path} or ${getAdditionalDownloadsAntScriptFile().path} in the SDK.")
+        }
     }
 
     /**
@@ -97,6 +101,9 @@ class InstallFlexSdkState extends AbstractInstallSdkState {
             if(!showPrompts) {
                 property(name: 'installer', value: true)
             }
+            property(name: 'do.air.install', value: true)
+            property(name: 'do.swfobject.install', value: true)
+            property(name: 'do.fontswf.install', value: true)
         }
     }
 


### PR DESCRIPTION
Flex 4.14 introduced new properties for its install ant script; if these properties are not set the proprietary components (AIR SDK, playerGlobal,..) will not be downloaded and thus the SDK will be unusable for GradleFX. This PR fixes this issue.

Note: This was actually a bugfix by the Flex team, the installed was supposed to ask for these properties just because of a bug it did not do so. For details see https://github.com/apache/flex-sdk/commit/67f1f5d3c522c723e0325b3a4aed68e518cb5e3b  

Note2: There is a new SDK for Starling called Feathers SDK that has similar structure as Flex 4.14, this commit makes it work with GradleFx. 