### PR TITLE
Log entry "Determine SDK install location": info -> debug

### DIFF
--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/AbstractCreateSdkInstallLocationState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/AbstractCreateSdkInstallLocationState.groovy
@@ -44,7 +44,7 @@ abstract class AbstractCreateSdkInstallLocationState implements SdkInitState {
     }
 
     void process(SdkInitialisationContext context) {
-        LOG.info("Determining SDK install location")
+        LOG.debug("Determining SDK install location")
 
         SdkInstallLocationFactory locationFactory = new SdkInstallLocationFactory(context.project)
         installLocation = locationFactory.createSdkLocation(sdkType)


### PR DESCRIPTION
This log entry occurs twice per project; with a lot of projects
configured (900 in our case), this creates a lot of noise,
especially considering we just set the SDK once.