### PR TITLE
FileCollection dependencies added as inputs to compile.

### DIFF
--- a/src/main/groovy/org/gradlefx/tasks/compile/Compile.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/compile/Compile.groovy
@@ -18,6 +18,7 @@ package org.gradlefx.tasks.compile
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.TaskAction
@@ -68,6 +69,11 @@ class Compile extends DefaultTask implements CompileTask {
                 Configurations.ARTIFACT_CONFIGURATIONS.each { Configurations configValue ->
                     inputs.files dependency.dependencyProject.configurations.getByName(configValue.configName()).allArtifacts.files
                 }
+            }
+
+            //add file collection dependencies as inputs to the compile task as well
+            configuration.getDependencies().withType(FileCollectionDependency).each { FileCollectionDependency dependency ->
+                inputs.files dependency.resolve()
             }
         }
     }


### PR DESCRIPTION
While we currently add project dependencies (their artifacts) as inputs
to the compile task, we were missing file collection dependencies.
This change rectifies this, which means any changes to file collection
dependencies will now cause the project to be recompiled.

Fixes issue #210.