### PR TITLE
Resolve #217: Properly detect if air needs to be installed

### DIFF
--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/AbstractCreateSdkInstallLocationState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/AbstractCreateSdkInstallLocationState.groovy
@@ -30,14 +30,14 @@ abstract class AbstractCreateSdkInstallLocationState implements SdkInitState {
     GradleFxConvention flexConvention
     SdkType sdkType
     SdkInstallLocation installLocation
-    String sdkFile
+    String sentryFilename
     protected String configName
     Boolean isInstallationRequired
     Boolean isInstalled
 
-    AbstractCreateSdkInstallLocationState(SdkType sdkType, String sdkFile, String configName, Boolean isInstallationRequired) {
+    AbstractCreateSdkInstallLocationState(SdkType sdkType, String sentryFilename, String configName, Boolean isInstallationRequired) {
         this.sdkType = sdkType
-        this.sdkFile = sdkFile
+        this.sentryFilename = sentryFilename
         this.configName = configName
         this.isInstallationRequired = isInstallationRequired
         this.isInstalled = false
@@ -54,6 +54,6 @@ abstract class AbstractCreateSdkInstallLocationState implements SdkInitState {
 
         project = context.project
 
-        isInstalled = new File(installLocation.directory, sdkFile).exists()
+        isInstalled = new File(installLocation.directory, sentryFilename).exists()
     }
 }

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/air/CreateAirSdkInstallLocationState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/air/CreateAirSdkInstallLocationState.groovy
@@ -24,7 +24,7 @@ import org.gradlefx.configuration.Configurations
 
 class CreateAirSdkInstallLocationState extends AbstractCreateSdkInstallLocationState {
     CreateAirSdkInstallLocationState(Boolean isInstallationRequired) {
-        super(SdkType.AIR, "lib/adt.jar", Configurations.AIRSDK_CONFIGURATION_NAME.configName(), isInstallationRequired)
+        super(SdkType.AIR, ".air.sentry", Configurations.AIRSDK_CONFIGURATION_NAME.configName(), isInstallationRequired)
     }
 
     @Override
@@ -36,7 +36,7 @@ class CreateAirSdkInstallLocationState extends AbstractCreateSdkInstallLocationS
 
         if (!isInstalled && isInstallationRequired) {
             Configuration flexSdkConfiguration = project.configurations.getByName(configName)
-            return new InstallAirSdkState(installLocation, flexSdkConfiguration.singleFile)
+            return new InstallAirSdkState(installLocation, flexSdkConfiguration.singleFile, sentryFilename)
         } else {
             return null;
         }

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/air/InstallAirSdkState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/air/InstallAirSdkState.groovy
@@ -23,7 +23,7 @@ class InstallAirSdkState extends AbstractInstallSdkState {
 
     private static final String SOME_AIR_SDK_ROOT_DIRECTORY = "frameworks"
 
-    InstallAirSdkState(SdkInstallLocation sdkInstallLocation, File packagedSdkFile) {
-        super(sdkInstallLocation, packagedSdkFile, SOME_AIR_SDK_ROOT_DIRECTORY)
+    InstallAirSdkState(SdkInstallLocation sdkInstallLocation, File packagedSdkFile, String sentryFilename) {
+        super(sdkInstallLocation, packagedSdkFile, SOME_AIR_SDK_ROOT_DIRECTORY, sentryFilename)
     }
 }

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/CreateFlexSdkInstallLocationState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/CreateFlexSdkInstallLocationState.groovy
@@ -24,7 +24,7 @@ import org.gradlefx.configuration.Configurations
 
 class CreateFlexSdkInstallLocationState extends AbstractCreateSdkInstallLocationState {
     CreateFlexSdkInstallLocationState(Boolean isInstallationRequired) {
-        super(SdkType.Flex, "lib/mxmlc.jar", Configurations.FLEXSDK_CONFIGURATION_NAME.configName(), isInstallationRequired)
+        super(SdkType.Flex, ".flex.sentry", Configurations.FLEXSDK_CONFIGURATION_NAME.configName(), isInstallationRequired)
     }
 
     @Override
@@ -36,7 +36,7 @@ class CreateFlexSdkInstallLocationState extends AbstractCreateSdkInstallLocation
 
         if (!isInstalled && isInstallationRequired) {
             Configuration flexSdkConfiguration = project.configurations.getByName(configName)
-            return new InstallFlexSdkState(installLocation, flexSdkConfiguration.singleFile)
+            return new InstallFlexSdkState(installLocation, flexSdkConfiguration.singleFile, sentryFilename)
         } else {
             return null;
         }

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/InstallFlexSdkState.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/flex/InstallFlexSdkState.groovy
@@ -28,8 +28,8 @@ class InstallFlexSdkState extends AbstractInstallSdkState {
     private static final String SDK_INSTALLER_CONFIG_URL = 'http://incubator.apache.org/flex/sdk-installer-config.xml'
     private static final String SOME_FLEX_SDK_ROOT_DIRECTORY = "frameworks"
 
-    InstallFlexSdkState(SdkInstallLocation sdkInstallLocation, File packagedSdkFile) {
-        super(sdkInstallLocation, packagedSdkFile, SOME_FLEX_SDK_ROOT_DIRECTORY)
+    InstallFlexSdkState(SdkInstallLocation sdkInstallLocation, File packagedSdkFile, String sentryFilename) {
+        super(sdkInstallLocation, packagedSdkFile, SOME_FLEX_SDK_ROOT_DIRECTORY, sentryFilename)
     }
 
     /**


### PR DESCRIPTION
Rely on airsdk.xml instead of lib/adt.jar which happens to be present in
some Flex SDK distributions (e.g. http://download.macromedia.com/pub/flex/sdk/flex_sdk_4.6.zip).

While airsdk.xml hasn't always been present on air distributions, it has
been bundled since air 3.2. Unfortunately there's no single file that
has always been present and that is not present in all Flex
distributions.