### PR TITLE
Resolve #219: recreate symlinks when autoinstalling SDK

### DIFF
--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/unpacking/AbstractSdkUnpacker.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/unpacking/AbstractSdkUnpacker.groovy
@@ -20,8 +20,12 @@ import org.gradle.api.file.FileTree
 import org.gradle.api.file.FileVisitDetails
 import org.gradlefx.configuration.sdk.SdkInstallLocation
 import org.gradle.api.Project
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 abstract class AbstractSdkUnpacker implements Unpacker {
+
+    protected static final Logger LOG = LoggerFactory.getLogger 'gradlefx'
 
     protected File packagedSdkFile
     protected String someSdkRootDirectoryName
@@ -87,5 +91,16 @@ abstract class AbstractSdkUnpacker implements Unpacker {
         }
 
         return relativeSdkLocation
+    }
+
+    protected static boolean execute(List args, File cwd) {
+        try {
+            def process = (args as String[]).execute((List)null, cwd)
+            LOG.info("Unpacking via '{}'", args.join(' '))
+            process.waitFor()
+            return process.exitValue() == 0
+        } catch (IOException) {
+            return false
+        }
     }
 }

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/unpacking/SdkTarGzUnpacker.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/unpacking/SdkTarGzUnpacker.groovy
@@ -26,13 +26,9 @@ class SdkTarGzUnpacker extends AbstractSdkUnpacker {
     }
 
     void unpackArchive() {
-        AntBuilder ant = new AntBuilder()
-        String tarFile = packagedSdkFile.absolutePath[0..-4]
+        if (execute([ "tar", "xf", packagedSdkFile.absolutePath ], sdkInstallLocation.directory))
+            return
 
-        ant.gunzip(src: packagedSdkFile.absolutePath, dest: tarFile)
-        ant.untar(src: tarFile, dest: sdkInstallLocation.directory.absolutePath, overwrite: "true")
-
-        //cleanup by removing the temporary tar archive
-        new File(tarFile).delete()
+        project.ant.untar(src: packagedSdkFile.absolutePath, dest: sdkInstallLocation.directory.absolutePath, overwrite: "true", compression: "gzip")
     }
 }

--- a/src/main/groovy/org/gradlefx/configuration/sdk/states/unpacking/SdkTbz2Unpacker.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/states/unpacking/SdkTbz2Unpacker.groovy
@@ -26,13 +26,9 @@ class SdkTbz2Unpacker extends AbstractSdkUnpacker {
     }
 
     void unpackArchive() {
-        AntBuilder ant = new AntBuilder()
-        String tarFile = packagedSdkFile.absolutePath[0..-5] + "tar"
+        if (execute([ "tar", "xf", packagedSdkFile.absolutePath ], sdkInstallLocation.directory))
+            return
 
-        ant.bunzip2(src: packagedSdkFile.absolutePath, dest: tarFile)
-        ant.untar(src: tarFile, dest: sdkInstallLocation.directory.absolutePath, overwrite: "true")
-
-        //cleanup by removing the temporary tar archive
-        new File(tarFile).delete()
+        project.ant.untar(src: packagedSdkFile.absolutePath, dest: sdkInstallLocation.directory.absolutePath, overwrite: "true", compression: "bzip2")
     }
 }


### PR DESCRIPTION
The SDK is unpacked using AntBuilder, and since Java is unable to create
symlinks, they are lost during the auto install procedure.

This fix attempts to unpack the .tgz or .tbz2 SDKs first by using `tar`.
If that fails (e.g. Windows), it resorts to the old method with
AntBuilder.