### PR TITLE
Add hideAneLibSymbols property

### DIFF
--- a/src/main/groovy/org/gradlefx/cli/compiler/CompilerOption.groovy
+++ b/src/main/groovy/org/gradlefx/cli/compiler/CompilerOption.groovy
@@ -1037,6 +1037,11 @@ public enum CompilerOption {
     PACKAGE("-package"),
 
     /**
+     * hide the ane lib symbols when there's multiple ANEs with the same functions name
+     */
+     HIDE_ANE_LIB_SYMBOLS("-hideAneLibSymbols"),
+
+    /**
      * packages an AIR application as an intermediate file (AIRI), but does not sign it. AIRI files cannot be installed.
      */
     PREPARE("-prepare"),

--- a/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
@@ -113,12 +113,19 @@ class AIRMobileConvention  {
     private Boolean nonLegacyCompiler
 
     /**
+     * Specifies whether -hideAneLibSymbols with flag 'yes' option is used ('no' is the default flag so no need to
+     * use it)
+     */
+    private Boolean hideAneLibSymbols
+
+    /**
      * (Android only, AIR 14 and higher) Application developers can use this argument to create APK for x86 platforms,
      * it takes following values:
      * armv7 - ADT packages APK for the Android armv7 platform. This is the default value when no value is specified.
      * x86 - ADT packages APK for the Android x86 platform.
      */
     private String arch
+
 
     /**
      * The -connect flag tells the AIR runtime on the device where to connect to a remote debugger over the network.
@@ -232,6 +239,14 @@ class AIRMobileConvention  {
 
     void setNonLegacyCompiler(Boolean nonLegacyCompiler) {
         this.nonLegacyCompiler = nonLegacyCompiler
+    }
+
+    Boolean getHideAneLibSymbols() {
+        return hideAneLibSymbols
+    }
+
+    void setHideAneLibSymbols(Boolean hideAneLibSymbols) {
+        this.hideAneLibSymbols = hideAneLibSymbols
     }
 
     String getArch() {

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -65,6 +65,10 @@ class BaseAirMobilePackage extends AdtTask {
             addArgs CompilerOption.USE_LEGACY_COMPILER.optionName, "no"
         }
 
+        if(flexConvention.airMobile.hideAneLibSymbols) {
+            addArgs CompilerOption.HIDE_ANE_LIB_SYMBOLS.optionName, "yes"
+        }
+
         if (StringUtils.isNotEmpty(flexConvention.airMobile.provisioningProfile)) {
             addArgs CompilerOption.PROVISIONING_PROFILE.optionName, flexConvention.airMobile.provisioningProfile
         }


### PR DESCRIPTION
Add hideAneLibSymbols property missing but necessary when multiple ANEs are present in the project