### PR TITLE
Added support for listenPort in airMobile convention (adt -listen flag)

### DIFF
--- a/src/main/groovy/org/gradlefx/cli/compiler/CompilerOption.groovy
+++ b/src/main/groovy/org/gradlefx/cli/compiler/CompilerOption.groovy
@@ -1246,9 +1246,16 @@ public enum CompilerOption {
 
     /**
      * The -connect flag tells the AIR runtime on the device where to connect to a remote debugger over the network.
-     * Applicaple for debug target type packages.
+     * Applicaple for debug target type packages. This option cannot be used with -listen flag together
      */
     CONNECT("-connect"),
+
+    /**
+     * The -listen flag tells the AIR runtime on the device to accept a connection from a debugger over a USB connection
+     * on a certain port.
+     * Applicaple for debug target type packages. This option cannot be used with -connect flag together
+     */
+    LISTEN("-listen"),
 
     //---------------//
     //---- asdoc ----//

--- a/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
@@ -126,12 +126,18 @@ class AIRMobileConvention  {
      */
     private String arch
 
-
     /**
      * The -connect flag tells the AIR runtime on the device where to connect to a remote debugger over the network.
      * Applicaple for debug target type packages.
      */
     private String connectHost
+
+    /**
+     * The -listen flag tells the AIR runtime on the device to accept a connection from a debugger over a USB connection
+     * on a certain port.
+     * Applicaple for debug target type packages. This option cannot be used with -connect flag together
+     */
+    private int listenPort
 
     public AIRMobileConvention(Project project) {
         target = 'apk'
@@ -263,5 +269,13 @@ class AIRMobileConvention  {
 
     void setConnectHost(String connectHost) {
         this.connectHost = connectHost
+    }
+
+    int getListenPort() {
+        return listenPort
+    }
+
+    void setListenPort(int listenPort) {
+        this.listenPort = listenPort
     }
 }

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -50,6 +50,8 @@ class BaseAirMobilePackage extends AdtTask {
         if(flexConvention.airMobile.connectHost) {
             addArg CompilerOption.CONNECT.optionName
             addArg flexConvention.airMobile.connectHost
+        } else if(flexConvention.airMobile.listenPort) {
+            addArgs CompilerOption.LISTEN.optionName, flexConvention.airMobile.listenPort
         }
 
         if(flexConvention.airMobile.arch) {

--- a/src/test/groovy/org/gradlefx/conventions/GradleFxConventionTest.groovy
+++ b/src/test/groovy/org/gradlefx/conventions/GradleFxConventionTest.groovy
@@ -328,6 +328,7 @@ class GradleFxConventionTest extends Specification {
             extensionDir = 'anedir'
             platformSdk = 'platformSdk'
             targetDevice = 'targetDevice'
+            listenPort = 7936
         }
 
         then:
@@ -335,6 +336,7 @@ class GradleFxConventionTest extends Specification {
         flexConvention.airMobile.extensionDir == 'anedir'
         flexConvention.airMobile.platformSdk == 'platformSdk'
         flexConvention.airMobile.targetDevice == 'targetDevice'
+        flexConvention.airMobile.listenPort == 7936
     }
 
 }


### PR DESCRIPTION
It was impossible to set -listen flag for adt. Added listenPort property of airMobile, which sets this flag. 