### PR TITLE
Support for ${version} and ${content} in applicationDescriptor files

### DIFF
--- a/src/main/groovy/org/gradlefx/cli/compiler/CompilerOption.groovy
+++ b/src/main/groovy/org/gradlefx/cli/compiler/CompilerOption.groovy
@@ -1246,9 +1246,16 @@ public enum CompilerOption {
 
     /**
      * The -connect flag tells the AIR runtime on the device where to connect to a remote debugger over the network.
-     * Applicaple for debug target type packages.
+     * Applicaple for debug target type packages. This option cannot be used with -listen flag together
      */
     CONNECT("-connect"),
+
+    /**
+     * The -listen flag tells the AIR runtime on the device to accept a connection from a debugger over a USB connection
+     * on a certain port.
+     * Applicaple for debug target type packages. This option cannot be used with -connect flag together
+     */
+    LISTEN("-listen"),
 
     //---------------//
     //---- asdoc ----//

--- a/src/main/groovy/org/gradlefx/conventions/AIRConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/AIRConvention.groovy
@@ -40,6 +40,7 @@ class AIRConvention {
     private String tsa
     /**
      * The location of the air descriptor file. Uses the project name by convention for this file.
+     * Supports @{version}, @{content} tokens
      */
     private String applicationDescriptor
     /**

--- a/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/AIRMobileConvention.groovy
@@ -126,12 +126,18 @@ class AIRMobileConvention  {
      */
     private String arch
 
-
     /**
      * The -connect flag tells the AIR runtime on the device where to connect to a remote debugger over the network.
      * Applicaple for debug target type packages.
      */
     private String connectHost
+
+    /**
+     * The -listen flag tells the AIR runtime on the device to accept a connection from a debugger over a USB connection
+     * on a certain port.
+     * Applicaple for debug target type packages. This option cannot be used with -connect flag together
+     */
+    private int listenPort
 
     public AIRMobileConvention(Project project) {
         target = 'apk'
@@ -263,5 +269,13 @@ class AIRMobileConvention  {
 
     void setConnectHost(String connectHost) {
         this.connectHost = connectHost
+    }
+
+    int getListenPort() {
+        return listenPort
+    }
+
+    void setListenPort(int listenPort) {
+        this.listenPort = listenPort
     }
 }

--- a/src/main/groovy/org/gradlefx/ide/tasks/AbstractIDEProject.groovy
+++ b/src/main/groovy/org/gradlefx/ide/tasks/AbstractIDEProject.groovy
@@ -29,8 +29,7 @@ import org.gradlefx.util.TemplateUtil
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-@Mixin(TemplateUtil)
-abstract class AbstractIDEProject extends DefaultTask implements ProjectTask {
+abstract class AbstractIDEProject extends DefaultTask implements ProjectTask, TemplateUtil {
 
     protected static final Logger LOG = LoggerFactory.getLogger 'gradlefx'
 

--- a/src/main/groovy/org/gradlefx/ide/tasks/idea/IdeaProject.groovy
+++ b/src/main/groovy/org/gradlefx/ide/tasks/idea/IdeaProject.groovy
@@ -281,7 +281,7 @@ class IdeaProject extends AbstractIDEProject {
         }
     }
 
-    private void addFilesInPackage(parent) {
+    protected void addFilesInPackage(parent) {
         def filesParent = new Node(parent, 'files-to-package', [])
 
         flexConvention.air.includeFileTrees.each { ConfigurableFileTree fileTree ->

--- a/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/AirPackage.groovy
@@ -21,12 +21,13 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileTreeElement
 import org.gradle.api.tasks.TaskAction
+import org.gradlefx.util.TemplateUtil
 import org.gradlefx.validators.actions.ValidateAirPackageTaskPropertiesAction
 import org.gradlefx.cli.compiler.CompilerOption;
 import org.gradlefx.conventions.FlexType;
 import org.gradlefx.conventions.GradleFxConvention
 
-class AirPackage extends DefaultTask {
+class AirPackage extends DefaultTask implements TemplateUtil {
 
     private static final String ANT_RESULT_PROPERTY = 'airPackageResult'
     private static final String ANT_OUTPUT_PROPERTY = 'airPackageOutput'
@@ -107,7 +108,7 @@ class AirPackage extends DefaultTask {
 
         airOptions.addAll([
             project.file(project.buildDir.name + '/' + flexConvention.output).absolutePath,
-            project.file(flexConvention.air.applicationDescriptor)
+            createFromTemplate(flexConvention.air.applicationDescriptor)
         ])
 
         addFiles(airOptions)

--- a/src/main/groovy/org/gradlefx/tasks/adl/AdlTask.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/adl/AdlTask.groovy
@@ -21,13 +21,14 @@ import org.gradle.api.tasks.TaskAction
 import org.gradlefx.conventions.GradleFxConvention
 import org.gradlefx.tasks.TaskGroups
 import org.gradlefx.tasks.Tasks
+import org.gradlefx.util.TemplateUtil
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 /**
  * Task which launches ADL.
  */
-class AdlTask extends DefaultTask {
+class AdlTask extends DefaultTask implements TemplateUtil {
 
     protected static final Logger LOG = LoggerFactory.getLogger 'gradlefx'
 
@@ -59,7 +60,7 @@ class AdlTask extends DefaultTask {
         addArgThatNotNull '-profile', flexConvention.adl.profile
         addArgThatNotNull '-screensize', flexConvention.adl.screenSize
 
-        addArgs flexConvention.air.applicationDescriptor
+        addArgs createFromTemplate(flexConvention.air.applicationDescriptor)
         addArgs project.projectDir
         def stdOut = new ByteArrayOutputStream();
 

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -50,6 +50,8 @@ class BaseAirMobilePackage extends AdtTask {
         if(flexConvention.airMobile.connectHost) {
             addArg CompilerOption.CONNECT.optionName
             addArg flexConvention.airMobile.connectHost
+        } else if(flexConvention.airMobile.listenPort) {
+            addArgs CompilerOption.LISTEN.optionName, flexConvention.airMobile.listenPort
         }
 
         if(flexConvention.airMobile.arch) {

--- a/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/mobile/BaseAirMobilePackage.groovy
@@ -25,11 +25,12 @@ import org.gradlefx.conventions.AIRMobileConvention
 import org.gradlefx.conventions.FlexType
 import org.gradlefx.tasks.Tasks
 import org.gradlefx.tasks.adt.AdtTask
+import org.gradlefx.util.TemplateUtil
 
 /**
  * Base task for packaging mobile apps.
  */
-class BaseAirMobilePackage extends AdtTask {
+class BaseAirMobilePackage extends AdtTask implements TemplateUtil {
 
     public BaseAirMobilePackage() {
         description = "Packages the generated swf file into an mobile package";
@@ -88,7 +89,7 @@ class BaseAirMobilePackage extends AdtTask {
         }
 
         addArgs outputPath
-        addArgs project.file(flexConvention.air.applicationDescriptor)
+        addArgs createFromTemplate(flexConvention.air.applicationDescriptor)
 
         addArg CompilerOption.CHANGE_DIRECTORY.optionName
         addArg project.buildDir.path

--- a/src/main/groovy/org/gradlefx/templates/tasks/Scaffold.groovy
+++ b/src/main/groovy/org/gradlefx/templates/tasks/Scaffold.groovy
@@ -28,9 +28,7 @@ import org.gradlefx.util.TemplateUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-@Mixin(TemplateUtil)
-class Scaffold extends DefaultTask {
+class Scaffold extends DefaultTask implements TemplateUtil {
     public static final String NAME = 'scaffold'
 
     protected static final Logger LOG = LoggerFactory.getLogger 'gradlefx'

--- a/src/main/groovy/org/gradlefx/util/TemplateUtil.groovy
+++ b/src/main/groovy/org/gradlefx/util/TemplateUtil.groovy
@@ -16,7 +16,7 @@
 
 package org.gradlefx.util
 
-class TemplateUtil {
+trait TemplateUtil {
 
    /**
     * Copies the content from a template file into a target file.

--- a/src/main/groovy/org/gradlefx/util/TemplateUtil.groovy
+++ b/src/main/groovy/org/gradlefx/util/TemplateUtil.groovy
@@ -19,6 +19,24 @@ package org.gradlefx.util
 trait TemplateUtil {
 
    /**
+    * Creates temporary file and copies the content from a template file with tokens
+    * replaced by {@link #writeContent}
+    *
+    * @param source The template on which the result will be based
+    */
+   public File createFromTemplate(String source, File output = null) {
+       InputStream template = project.file(source).newInputStream()
+
+       if(!output) {
+           output = File.createTempFile(source, null)
+           output.deleteOnExit()
+       }
+
+       writeContent template, output, true
+       output
+   }
+
+   /**
     * Copies the content from a template file into a target file.
     * In this process the following tokens are being replaced:
     * <ul>

--- a/src/test/groovy/org/gradlefx/conventions/GradleFxConventionTest.groovy
+++ b/src/test/groovy/org/gradlefx/conventions/GradleFxConventionTest.groovy
@@ -328,6 +328,7 @@ class GradleFxConventionTest extends Specification {
             extensionDir = 'anedir'
             platformSdk = 'platformSdk'
             targetDevice = 'targetDevice'
+            listenPort = 7936
         }
 
         then:
@@ -335,6 +336,7 @@ class GradleFxConventionTest extends Specification {
         flexConvention.airMobile.extensionDir == 'anedir'
         flexConvention.airMobile.platformSdk == 'platformSdk'
         flexConvention.airMobile.targetDevice == 'targetDevice'
+        flexConvention.airMobile.listenPort == 7936
     }
 
 }

--- a/src/test/groovy/org/gradlefx/util/StubTemplateUtilBase.groovy
+++ b/src/test/groovy/org/gradlefx/util/StubTemplateUtilBase.groovy
@@ -16,11 +16,10 @@
 
 package org.gradlefx.util
 
-import org.gradlefx.conventions.GradleFxConvention
 import org.gradle.api.Project
+import org.gradlefx.conventions.GradleFxConvention
 
-@Mixin(TemplateUtil)
-class StubTemplateUtilBase {
+class StubTemplateUtilBase implements TemplateUtil {
 
     public GradleFxConvention flexConvention
 


### PR DESCRIPTION
Code creates a new temporary file from applicationDescriptor file and replaces tokens