### PR TITLE
Fixed weird behaviour of command value for flexUnit block

### DIFF
--- a/src/main/groovy/org/gradlefx/conventions/FlexUnitConvention.groovy
+++ b/src/main/groovy/org/gradlefx/conventions/FlexUnitConvention.groovy
@@ -28,7 +28,7 @@ class FlexUnitConvention {
 
     private String template //can be used for a custom template
     private String player           = 'flash'
-    private String command          = System.getenv()['FLASH_PLAYER_EXE']
+    private String command
     private String toDir
     private String workingDir
     private Boolean haltOnFailure   = false
@@ -46,7 +46,7 @@ class FlexUnitConvention {
     private String swfName          = 'TestRunner.swf'
     //list of additional compiler options as defined by the compc or mxmlc compiler
     private List <String> additionalCompilerOptions = []
-    
+
     public FlexUnitConvention(Project project) {
         toDir       = "${project.buildDir}/reports"
         workingDir  = project.buildDir.path

--- a/src/main/groovy/org/gradlefx/tasks/TestFx.groovy
+++ b/src/main/groovy/org/gradlefx/tasks/TestFx.groovy
@@ -223,10 +223,18 @@ class TestFx extends DefaultTask {
         return flexUnit.command
     }
 
+    /**
+     * Returns default value for FlexUnit's command field
+     *
+     * @return path to adl for 'air' player, path to flash player executable for 'flash' player
+     */
     private String findFlexUnitCommand() {
         if (flexUnit.player == 'air')
             return getAdlPath()
-        throwMissingCommandException("The Flash player executable is not found")
+        else if (flexUnit.player == 'flash') {
+            return getFlashPlayerPath()
+        }
+        throwMissingCommandException("Incorrect player type")
     }
 
     private String getAdlPath() {
@@ -237,6 +245,15 @@ class TestFx extends DefaultTask {
         if (!adlPath.canExecute())
             throwMissingCommandException("Unable to locate the ADL executable at $adlPath.absolutePath")
         return adlPath
+    }
+
+
+    private String getFlashPlayerPath() {
+        def flashPath = new File(System.getenv()['FLASH_PLAYER_EXE']);
+        if (!flashPath.canExecute())
+            throwMissingCommandException("The Flash player executable is not found")
+
+        return flashPath
     }
 
     private static void throwMissingCommandException(String message) {


### PR DESCRIPTION
Now don't need to set command to null if you need to use default path to adl