### PR TITLE
Fixed "Could not find matching constructor for: org.gradlefx.configur…

### DIFF
--- a/src/main/groovy/org/gradlefx/configuration/sdk/SdkInstallLocationFactory.groovy
+++ b/src/main/groovy/org/gradlefx/configuration/sdk/SdkInstallLocationFactory.groovy
@@ -34,7 +34,7 @@ class SdkInstallLocationFactory {
     Project project
     String sentryFilename
 
-    SdkInstallLocationFactory(Project project, String sentryFilename) {
+    SdkInstallLocationFactory(Project project, String sentryFilename = null) {
         this.project = project
         this.sentryFilename = sentryFilename
         gradleFxConvention = (GradleFxConvention) project.convention.plugins.flex


### PR DESCRIPTION
There is an exception on call "cleanSdks" task:

`Could not find matching constructor for: org.gradlefx.configuration.sdk.SdkInstallLocationFactory(org.gradle.api.internal.project.DefaultProject_Decorated)`