### PR TITLE
issue259: Disable rather than remove tasks.

### DIFF
--- a/src/main/groovy/org/gradlefx/plugins/AbstractGradleFxPlugin.groovy
+++ b/src/main/groovy/org/gradlefx/plugins/AbstractGradleFxPlugin.groovy
@@ -74,16 +74,16 @@ abstract class AbstractGradleFxPlugin implements Plugin<Project> {
     protected Task addTask(String name, Class taskClass) {
         return project.tasks.create(name, taskClass)
     }
-    
+
     protected Task addTask(String name, Class taskClass, Closure condition) {
         //always add tasks to make sure they are immediately on the task graph,
-        //but remove them after evaluation if it turns out we don't need them
+        //but disable them after evaluation if it turns out we don't need them
         Task task = project.tasks.create name, taskClass
-        
+
         project.afterEvaluate {
-            if (!condition()) project.tasks.remove task
+            if (!condition()) task.enabled = false
         }
-        
+
         return task
     }
     


### PR DESCRIPTION
TaskContainer.remove support has been removed in Gradle 6 - ref: https://docs.gradle.org/current/userguide/upgrading_version_5.html

Since gradlefx uses this call, this call has been removed in place of a disable call to allow support for Gradle 6.